### PR TITLE
Workaround for onSetErrorHandler() crash

### DIFF
--- a/disableZRay.php
+++ b/disableZRay.php
@@ -1,0 +1,2 @@
+<?php
+zray_disable(true);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit colors="true" bootstrap="disableZRay.php">
     <testsuites>
         <testsuite name="PHP Test Suite">
             <directory>./tests</directory>


### PR DESCRIPTION
Sorry about the crash. However, this (or similar) workaround should be OK for PHPUnit - Z-Ray is not really required during unit testing and may even contaminate some of the results.